### PR TITLE
Mise en place des regles de gestion cote front #14

### DIFF
--- a/src/app/jourFerie/creation-jour-ferie/creation-jour-ferie.component.html
+++ b/src/app/jourFerie/creation-jour-ferie/creation-jour-ferie.component.html
@@ -20,7 +20,7 @@
 		<label for="commentaireJourFerme" class="col-sm-2 col-form-label">Commentaire</label>
 		<div class="col-sm-10">
 			<textarea class="form-control" id="commentaireJourFerme" rows="3"
-				formControlName="commentaireJourFerme" required></textarea>
+				formControlName="commentaireJourFerme"></textarea>
 		</div>
 	</div>
 	<button class="btn btn-success" [disabled]="formCreationJourFerme.invalid">Valider</button>

--- a/src/app/jourFerie/creation-jour-ferie/creation-jour-ferie.component.ts
+++ b/src/app/jourFerie/creation-jour-ferie/creation-jour-ferie.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { JourFermeService } from 'src/app/service/jour-ferme.service';
+import { formatDate } from '@angular/common';
 
 @Component({
   selector: 'app-creation-jour-ferie',
@@ -13,9 +14,9 @@ export class CreationJourFerieComponent implements OnInit {
   formCreationJourFerme: FormGroup;
   messageErreur = '';
   messageValidation = '';
-  constructor(private router: Router, 
+  constructor(private router: Router,
     private formBuilder: FormBuilder,
-    private jourFermeService : JourFermeService) { }
+    private jourFermeService: JourFermeService) { }
 
   ngOnInit(): void {
     this.initialiserFormulaire();
@@ -25,7 +26,7 @@ export class CreationJourFerieComponent implements OnInit {
     this.formCreationJourFerme = this.formBuilder.group({
       dateJourFerme: ['', Validators.required],
       typeJourFerme: ['', Validators.required],
-      commentaireJourFerme: ['', Validators.required]
+      commentaireJourFerme: ['']
     });
   }
   validerFormulaire() {
@@ -35,29 +36,47 @@ export class CreationJourFerieComponent implements OnInit {
     const typeJourFerme = this.formCreationJourFerme.get('typeJourFerme').value;
     const commentaireJourFerme = this.formCreationJourFerme.get('commentaireJourFerme').value;
 
-    // if (typeJourFerme < Date.now()) {
-    //   console.log('Date dans le passé, erreur');
-    // }
+    // on formate la date du jour au format 'yyyy-MM-dd'
+    const dateAujourdhui = formatDate(Date.now(), 'yyyy-MM-dd', 'en-US');
 
-    // Mise à jour message de validation
-    this.messageValidation = 'Fomulaire validé';
+    // Verifier jour de la semaine
+    const jourSaisie = formatDate(dateJourFerme, 'E', 'en-US');
 
-    // Affichage des données récupérées
-    console.log(dateJourFerme + typeJourFerme + commentaireJourFerme);
+    // Vérification du jour saisi
+    // Cas 1 , jour saisi est dans le passé, erreur
+    // Cas 2 , saisie RTT le WE, erreur
+    // Cas 3 , cas JOUR FERIE et commentaire manquant
+    // Cas 4 , jour saisi est dans le futur, ok
 
-    // Redirection vers la liste des jours feriés en cas de réussite
-    //this.router.navigate(['listerJourFerie']);
+    if (dateJourFerme < dateAujourdhui)
+    {
+      this.messageErreur = 'ERREUR. SAISIE DANS LE PASSE IMPOSSIBLE.';
+    }
+    else if (typeJourFerme === 'RTT_EMPLOYEUR' && (jourSaisie === 'Sat' || jourSaisie === 'Sun'))
+    {
+      this.messageErreur = 'ERREUR. IMPOSSIBLE DE SAISIE UN RTT LE WEEK-END.';
+    }
+    else if (typeJourFerme === 'JOURS_FERIES' && commentaireJourFerme === '') 
+    {
+      this.messageErreur = 'ERREUR. LE COMMENTAIRE EST OBLIGATOIRE POUR LES JOURS FERIES.';
+    }
+    else
+    {
+      this.jourFermeService.ajouterJourFerme(dateJourFerme, typeJourFerme, commentaireJourFerme).subscribe(
+        () => { },
+        (error) => {
+          this.messageErreur = 'ERREUR';
+        }, () => {
+          this.messageValidation = 'FORMULAIRE VALIDE !';
+          this.messageErreur = '';
+          setTimeout(() => {
+            // Redirection au bout de 2 secondes
+            this.router.navigate(['listerJourFerie']);
+          }, 2000);
+        }
+      );
+    }
 
-    this.jourFermeService.ajouterJourFerme(dateJourFerme, typeJourFerme, commentaireJourFerme).subscribe(
-    () => { },
-      (error) => {
-        this.messageErreur = ' Oulah, il y a un probleme mec';
-      }, () => {
-        this.messageValidation = 'Formulaire validé !';
-        setTimeout(() => {
-          this.router.navigate(['listerJourFerie']);
-        }, 2000);
-      }
-    );
+
   }
 }


### PR DESCRIPTION
Mise en place des règles de gestion coté front
1 manquante : "il est interdit de saisir un jour férié à la même date qu'un autre jour férié"